### PR TITLE
Attempt to handle empty comment fields properly

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -77,10 +77,11 @@ def main():
             json_file.write(json.dumps(post, indent=2, sort_keys=True))
         html_filename = "%s/post_%s.html" % (folder, post["id"])
         with open(html_filename, "wb") as html_file:
-            html_file.write(post["post_body"].encode("utf8"))
+            if "post_body" in post and post["post_body"] is not None:
+                html_file.write(post["post_body"].encode("utf8"))
         count += 1
     print("Dumped %d posts." % count)
-    
+
     # export comments
     count = 0
     for comment in hsclient.iterate_comments():

--- a/to_wxr.py
+++ b/to_wxr.py
@@ -32,10 +32,10 @@ if __name__ == "__main__":
     for post_id in os.listdir(path):
         subdir = "/".join((path, post_id))
         post_file = "%s/post_%s.json" % (subdir, post_id)
-        
+
         if not os.path.exists(post_file):
             continue
-        
+
         # read JSON file
         post = None
         with open(post_file, "rb") as jsonfile:
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
         creator = etree.SubElement(item, "{http://purl.org/dc/elements/1.1/}creator")
         creator.text = post["blog_author"]["full_name"]
-            
+
         content = etree.SubElement(item, "{http://purl.org/rss/1.0/modules/content/}encoded")
         content.text = etree.CDATA("")
         if post["post_body"] is not None:
@@ -63,17 +63,17 @@ if __name__ == "__main__":
         # This remains empty
         thread_id = etree.SubElement(item, "{http://www.disqus.com/}thread_identifier")
         thread_id.text = post["slug"]
-        
+
         wp_post_date = etree.SubElement(item, "{http://wordpress.org/export/1.0/}post_date_gmt")
         wp_post_date.text = datetime.fromtimestamp(post["publish_date"] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-        
+
         wp_comment_status = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_status")
         wp_comment_status.text = "open"
-        
+
         comment_dir = "%s/comments" % subdir
-        
+
         if os.path.exists(comment_dir):
-            
+
             for comment_file in os.listdir(comment_dir):
                 comment_path = "%s/%s" % (comment_dir, comment_file)
                 print(comment_path)
@@ -87,30 +87,30 @@ if __name__ == "__main__":
 
                 comment_author = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_author")
                 comment_author.text = comment_data["userName"]
-                
+
                 comment_author_email = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_author_email")
                 comment_author_email.text = comment_data["userEmail"]
-                
+
                 comment_date_gmt = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_date_gmt")
                 comment_date_gmt.text = datetime.fromtimestamp(comment_data["createdAt"] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-                
+
                 comment_author_url = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_author_url")
                 if comment_data["userUrl"] is not None:
                     comment_author_url.text = comment_data["userUrl"]
-                
+
                 comment_author_ip = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_author_IP")
                 if comment_data["userIp"] is not None:
                     comment_author_ip.text = comment_data["userIp"]
 
                 comment_content = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_content")
                 comment_content.text = etree.CDATA(comment_data["comment"])
-                
+
                 comment_approved = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_approved")
                 if comment_data["state"] == "APPROVED":
                     comment_approved.text = "1"
                 else:
                     comment_approved.text = "0"
-                
+
                 comment_parent = etree.SubElement(item, "{http://wordpress.org/export/1.0/}comment_parent")
                 if comment_data["parent"]["id"] != 0:
                     comment_parent.text = str(comment_data["parent"]["id"])

--- a/to_wxr.py
+++ b/to_wxr.py
@@ -53,7 +53,10 @@ if __name__ == "__main__":
         link.text = post["published_url"]
 
         creator = etree.SubElement(item, "{http://purl.org/dc/elements/1.1/}creator")
-        creator.text = post["blog_author"]["full_name"]
+        try:
+            creator.text = post["blog_author"]["full_name"]
+        except KeyError:
+            creator.text = "Unnamed Author"
 
         content = etree.SubElement(item, "{http://purl.org/rss/1.0/modules/content/}encoded")
         content.text = etree.CDATA("")

--- a/to_wxr.py
+++ b/to_wxr.py
@@ -56,8 +56,10 @@ if __name__ == "__main__":
         creator.text = post["blog_author"]["full_name"]
             
         content = etree.SubElement(item, "{http://purl.org/rss/1.0/modules/content/}encoded")
-        content.text = etree.CDATA(post["post_body"])
-        
+        content.text = etree.CDATA("")
+        if post["post_body"] is not None:
+            content.text = etree.CDATA(post["post_body"])
+
         # This remains empty
         thread_id = etree.SubElement(item, "{http://www.disqus.com/}thread_identifier")
         thread_id.text = post["slug"]


### PR DESCRIPTION
This attempts to fix #1, where an empty `post_body` or non existing author `full_name` breaks the execution of `to_wxr.py`.
