### PR TITLE
Add support for HubSpot authors and topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv/
 export/
 config.py
+ghost.json
+disqus.xml

--- a/dump.py
+++ b/dump.py
@@ -42,6 +42,22 @@ class Client(object):
         for blog in r.json()["objects"]:
             yield blog
 
+    def iterate_authors(self):
+        """Get authors for blog"""
+        url = "/blogs/v3/blog-authors"
+        r = self.__get_request(url, additional_params={"limit": 100})
+        r.raise_for_status()
+        for author in r.json()["objects"]:
+            yield author
+
+    def iterate_topics(self):
+        """Get topics for blog"""
+        url = "/blogs/v3/topics"
+        r = self.__get_request(url, additional_params={"limit": 100})
+        r.raise_for_status()
+        for topic in r.json()["objects"]:
+            yield topic
+
     def iterate_posts(self):
         """Get iterator of blog posts of a blog"""
         url = "/content/api/v2/blog-posts"
@@ -67,11 +83,39 @@ def main():
 
     print("Dumping blog content to '%s'..." % export_dir)
 
+    # export authors
+    count = 0
+    for author in hsclient.iterate_authors():
+        folder = os.path.join(export_dir, "authors", str(author["id"]))
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        json_filename = "%s/author_%s.json" % (folder, author["id"])
+        with open(json_filename, "wb") as json_file:
+            json_file.write(json.dumps(author, indent=2, sort_keys=True))
+        count += 1
+    print("Dumped %d authors." % count)
+
+    # export topics
+    count = 0
+    # topics = []
+    for topic in hsclient.iterate_topics():
+        # topics.append(topic)
+        # count += 1
+        folder = os.path.join(export_dir, "topics", str(topic["id"]))
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        json_filename = "%s/topic_%s.json" % (folder, topic["id"])
+        with open(json_filename, "wb") as json_file:
+            json_file.write(json.dumps(topic, indent=2, sort_keys=True))
+        count += 1
+    print("Dumped %d topics." % count)
+
     # export posts
     count = 0
     for post in hsclient.iterate_posts():
-        folder = "/".join([export_dir, str(post["id"])])
-        os.makedirs(folder)
+        folder = os.path.join(export_dir, "posts", str(post["id"]))
+        if not os.path.exists(folder):
+            os.makedirs(folder)
         json_filename = "%s/post_%s.json" % (folder, post["id"])
         with open(json_filename, "wb") as json_file:
             json_file.write(json.dumps(post, indent=2, sort_keys=True))
@@ -85,7 +129,7 @@ def main():
     # export comments
     count = 0
     for comment in hsclient.iterate_comments():
-        folder = "%s/%s/comments" % (export_dir, comment["contentId"])
+        folder = os.path.join(export_dir, "comments", str(comment["contentId"]))
         if not os.path.exists(folder):
             os.makedirs(folder)
         json_filename = "%s/comment_%s.json" % (folder, comment["id"])

--- a/to_ghost.py
+++ b/to_ghost.py
@@ -11,7 +11,7 @@ import json
 from datetime import datetime
 import time
 
-path = "export"
+basepath = "export"
 
 
 if __name__ == "__main__":
@@ -29,18 +29,82 @@ if __name__ == "__main__":
             "roles_users": []
         }
     }
-    
-    for post_id in os.listdir(path):
-        subdir = "/".join((path, post_id))
+
+
+
+
+    # append all of the author objects
+    for author_id in os.listdir(os.path.join(basepath, "authors")):
+        subdir = os.path.join(basepath, "authors", author_id)
+        author_file = "%s/author_%s.json" % (subdir, author_id)
+
+        if not os.path.exists(author_file):
+            continue
+
+        author = None
+        with open(author_file, "rb") as jsonfile:
+            author = json.load(jsonfile)
+
+        if len(author["bio"]) > 200:
+            print("Truncated author bio for '%s'" % author["fullName"])
+
+        out_user = {
+            "id": author["id"],
+            "name": author["fullName"],
+            "slug": author["slug"],
+            "email": author["email"],
+            "bio": author["bio"][:200],
+            "website": author["website"],
+            "twitter": author["twitterUsername"],
+        }
+
+        out["data"]["users"].append(out_user)
+
+
+
+
+    # append all of the tag objects
+    for topic_id in os.listdir(os.path.join(basepath, "topics")):
+        subdir = os.path.join(basepath, "topics", topic_id)
+        topic_file = "%s/topic_%s.json" % (subdir, topic_id)
+
+        if not os.path.exists(topic_file):
+            continue
+
+        topic = None
+        with open(topic_file, "rb") as jsonfile:
+            topic = json.load(jsonfile)
+
+        if len(topic["description"]) > 200:
+            print("Truncated topic description for '%s'" % topic["name"])
+
+        out_tag = {
+            "id": topic["id"],
+            "name": topic["name"],
+            "slug": topic["slug"],
+            "description": topic["description"][:200],
+        }
+
+        out["data"]["tags"].append(out_tag)
+
+
+
+
+    # append all of the post objects
+    for post_id in os.listdir(os.path.join(basepath, "posts")):
+        subdir = os.path.join(basepath, "posts", post_id)
         post_file = "%s/post_%s.json" % (subdir, post_id)
-        
+
         if not os.path.exists(post_file):
             continue
-        
+
         # read JSON file
         post = None
         with open(post_file, "rb") as jsonfile:
             post = json.load(jsonfile)
+
+        if len(post["meta_description"]) > 200:
+            print("Truncated post meta description for '%s'" % post["name"])
 
         out_post = {
             "id": post["id"],
@@ -54,18 +118,26 @@ if __name__ == "__main__":
             "status": "published",
             "language": "en_US",
             "meta_title": None,
-            "meta_description": post["meta_description"],
-            "author_id": 1,
+            "meta_description": post["meta_description"][:200],
+            "author_id": post["blog_author_id"],
             "created_at": post["created"],
-            "created_by": 1,
+            "created_by": post["blog_author_id"],
             "updated_at": post["publish_date"],
-            "updated_by": 1,
+            "updated_by": post["blog_author_id"],
             "published_at": post["publish_date"],
-            "published_by": 1
+            "published_by": post["blog_author_id"],
         }
-        
+
         out["data"]["posts"].append(out_post)
-        
+
+        # build all the post's tag objects
+        for topic_id in post["topic_ids"]:
+            out_post_tag = {
+                "post_id": post["id"],
+                "tag_id": topic_id,
+            }
+            out["data"]["posts_tags"].append(out_post_tag)
+
 
     f = open("ghost.json", "wb")
     f.write(json.dumps(out, indent=2, sort_keys=True))


### PR DESCRIPTION
Adds support for exporting authors and topics from HubSpot using the export script, `dump.py`. Also modifies the ghost format conversion script `to_ghost.py` utilize this new export data.

Please note there is some wonkiness with import authors in Ghost, especially if you already have authors in your current installation. If this pull request gets any attention I will be happy to follow it up with a config flag to disable the authors part of the export.